### PR TITLE
Enable button reads on all free digital pins

### DIFF
--- a/Code/Traktorino/Traktorino.ino
+++ b/Code/Traktorino/Traktorino.ino
@@ -45,10 +45,10 @@ MIDI_CREATE_DEFAULT_INSTANCE();
 /////////////////////////////////////////////
 // buttons
 const byte muxNButtons = 13; // *coloque aqui o numero de entradas digitais utilizadas no multiplexer
-const byte NButtons = 0; // *coloque aqui o numero de entradas digitais utilizadas
+const byte NButtons = 6; // *coloque aqui o numero de entradas digitais utilizadas
 const byte totalButtons = muxNButtons + NButtons;
 const byte muxButtonPin[muxNButtons] = {0, 1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14, 15}; // *neste array coloque na ordem desejada os pinos das portas digitais utilizadas
-const byte buttonPin[NButtons] = {}; // *neste array coloque na ordem desejada os pinos das portas digitais utilizadas
+const byte buttonPin[NButtons] = {9, 13, A2, A3, A4, A5}; // *neste array coloque na ordem desejada os pinos das portas digitais utilizadas
 int buttonCState[totalButtons] = {0}; // estado atual da porta digital
 int buttonPState[totalButtons] = {0}; // estado previo da porta digital
 


### PR DESCRIPTION
Enables buttons on free digital pins, including:
- pin 9 for encoder click
- pin 16 on front headers
- pins A2, A3, A4, and A5 on front headers