### PR TITLE
Enables buttons on free digital pins

### DIFF
--- a/Code/Traktorino/Traktorino.ino
+++ b/Code/Traktorino/Traktorino.ino
@@ -45,10 +45,10 @@ MIDI_CREATE_DEFAULT_INSTANCE();
 /////////////////////////////////////////////
 // buttons
 const byte muxNButtons = 13; // *coloque aqui o numero de entradas digitais utilizadas no multiplexer
-const byte NButtons = 0; // *coloque aqui o numero de entradas digitais utilizadas
+const byte NButtons = 6; // *coloque aqui o numero de entradas digitais utilizadas
 const byte totalButtons = muxNButtons + NButtons;
 const byte muxButtonPin[muxNButtons] = {0, 1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14, 15}; // *neste array coloque na ordem desejada os pinos das portas digitais utilizadas
-const byte buttonPin[NButtons] = {}; // *neste array coloque na ordem desejada os pinos das portas digitais utilizadas
+const byte buttonPin[NButtons] = {9, 13, A2, A3, A4, A5}; // *neste array coloque na ordem desejada os pinos das portas digitais utilizadas
 int buttonCState[totalButtons] = {0}; // estado atual da porta digital
 int buttonPState[totalButtons] = {0}; // estado previo da porta digital
 

--- a/Code/Traktorino/Traktorino.ino
+++ b/Code/Traktorino/Traktorino.ino
@@ -124,7 +124,9 @@ Thread threadReadButtons; // thread para controlar os botoes
 void setup() {
 
   Serial.begin(31250); // 115200 for hairless - 31250 for MOCO lufa
-
+  
+  MIDI.turnThruOff();
+  
   /////////////////////////////////////////////
   // Midi in
   MIDI.setHandleControlChange(handleControlChange);

--- a/Code/Traktorino/Traktorino.ino
+++ b/Code/Traktorino/Traktorino.ino
@@ -138,6 +138,12 @@ void setup() {
   pinMode(A1, INPUT_PULLUP); // Buttons need input pull up
 
   /////////////////////////////////////////////
+  // buttons on Arduino Digital pins
+  for (int i = 0; i < NButtons; i++) { // buttons on Digital pins
+    pinMode(buttonPin[i], INPUT_PULLUP);
+  }
+  
+  /////////////////////////////////////////////
   // Leds
   //  leds.setBitCount(ledNum); // Mux Leds
   //  leds.setPins(clockPin, dataPin, latchPin);

--- a/Code/Traktorino/Traktorino.ino
+++ b/Code/Traktorino/Traktorino.ino
@@ -45,10 +45,10 @@ MIDI_CREATE_DEFAULT_INSTANCE();
 /////////////////////////////////////////////
 // buttons
 const byte muxNButtons = 13; // *coloque aqui o numero de entradas digitais utilizadas no multiplexer
-const byte NButtons = 0; // *coloque aqui o numero de entradas digitais utilizadas
+const byte NButtons = 1; // *coloque aqui o numero de entradas digitais utilizadas
 const byte totalButtons = muxNButtons + NButtons;
 const byte muxButtonPin[muxNButtons] = {0, 1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14, 15}; // *neste array coloque na ordem desejada os pinos das portas digitais utilizadas
-const byte buttonPin[NButtons] = {}; // *neste array coloque na ordem desejada os pinos das portas digitais utilizadas
+const byte buttonPin[NButtons] = {9}; // *neste array coloque na ordem desejada os pinos das portas digitais utilizadas
 int buttonCState[totalButtons] = {0}; // estado atual da porta digital
 int buttonPState[totalButtons] = {0}; // estado previo da porta digital
 
@@ -137,6 +137,12 @@ void setup() {
   mplexButtons.begin(); // inicializa o multiplexer
   pinMode(A1, INPUT_PULLUP); // Buttons need input pull up
 
+  /////////////////////////////////////////////
+  // buttons on Arduino Digital pins
+  for (int i = 0; i < NButtons; i++) { //read buttons on Arduino
+    pinMode(buttonPin[i], INPUT_PULLUP); // stores in the rest of buttonCState
+  }
+  
   /////////////////////////////////////////////
   // Leds
   //  leds.setBitCount(ledNum); // Mux Leds


### PR DESCRIPTION
Enables buttons on free digital pins, including:

pin 9 for encoder click
pin 16 on front headers
pins A2, A3, A4, and A5 on front headers